### PR TITLE
Fix bug related to changing setting ROIs and starting sequence acquisitions

### DIFF
--- a/MMCore/MMCore.cpp
+++ b/MMCore/MMCore.cpp
@@ -2821,6 +2821,13 @@ void CMMCore::startSequenceAcquisition(const char* label, long numImages, double
       throw CMMError(getCoreErrorText(MMERR_NotAllowedDuringSequenceAcquisition).c_str(),
                      MMERR_NotAllowedDuringSequenceAcquisition);
 
+   if (!cbuf_->Initialize(pCam->GetNumberOfChannels(), pCam->GetImageWidth(), pCam->GetImageHeight(), pCam->GetImageBytesPerPixel()))
+   {
+      logError(getDeviceName(pCam).c_str(), getCoreErrorText(MMERR_CircularBufferFailedToInitialize).c_str());
+      throw CMMError(getCoreErrorText(MMERR_CircularBufferFailedToInitialize).c_str(), MMERR_CircularBufferFailedToInitialize);
+   }
+   cbuf_->Clear();
+	
    LOG_DEBUG(coreLogger_) <<
       "Will start sequence acquisition from camera " << label;
    int nRet = pCam->StartSequenceAcquisition(numImages, intervalMs, stopOnOverflow);


### PR DESCRIPTION
I don't have access to my setup Core deve environment at the moment, so it would be great if someone can verify if this change is correct (or if not I can do it in a few weeks).

With the current version of the acq engine, a bug has arisen where the expected number of images don't arrive if an ROI has been set. See: https://github.com/micro-manager/pycro-manager/issues/620. We also have a automated test in PM that checks this (which currently fails): https://github.com/micro-manager/pycro-manager/pull/638

The bug seems to arise from difference between the two versions of`startSequenceAcquisition` which take a camera label vs using `Core-Camera`. The acquisition engine uses the former version, because this is needed to run two cameras in parallel (as the diSPIM does). 

This can be reproduced with the following script:
```python
from pycromanager import Core
import time

mmc = Core()
mmc.set_property('Camera', 'OnCameraCCDXSize', '1024')
mmc.set_property('Camera', 'OnCameraCCDYSize', '1024')

image_count = 5

camera_name = mmc.get_camera_device()
mmc.prepare_sequence_acquisition(camera_name);

mmc.start_sequence_acquisition(camera_name, image_count, 0, True);
start = time.time()

while mmc.is_sequence_running(camera_name):
    time.sleep(0.1)
    print('Sequence running' )
    if mmc.is_buffer_overflowed():
        print('Buffer overflowed')
        break

print('Sequence done in ' + str(time.time() - start) + ' seconds')
while mmc.get_remaining_image_count() > 0:
    try:
        ti = mmc.pop_next_tagged_image()
        print('Got image')
    except:
        print('No image ready')
        continue
```

I think the proposed fix will solve this, because adding the line `mmc.initialize_circular_buffer()` to the above script after setting the ROI seems to do it.

